### PR TITLE
#162241874 Fix build status badge showing unknown build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/samuelbwambale/my-diary-react.svg?branch=master)](https://travis-ci.org/samuelbwambale/my-diary-react)[![Maintainability](https://api.codeclimate.com/v1/badges/bb80b932bec5ef1ede3d/maintainability)](https://codeclimate.com/github/samuelbwambale/my-diary-react/maintainability)
+[![Build Status](https://travis-ci.org/samuelbwambale/my-diary-react.svg?branch=develop)](https://travis-ci.org/samuelbwambale/my-diary-react)
+[![Maintainability](https://api.codeclimate.com/v1/badges/bb80b932bec5ef1ede3d/maintainability)](https://codeclimate.com/github/samuelbwambale/my-diary-react/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/bb80b932bec5ef1ede3d/test_coverage)](https://codeclimate.com/github/samuelbwambale/my-diary-react/test_coverage)
 
 # my-diary-react


### PR DESCRIPTION
### What does this PR do?

Fixes the build badge showing unknown build status

#### Description of Task to be completed?

Currently, the build badge in the readme file is not showing the build status. This is because the badge points to the master branch which is not the default branch.

This fix changes the branch from master to develop

#### How should this be manually tested?

View the travis build badge in the README file


#### What are the relevant pivotal tracker stories?

- [#162241874](https://www.pivotaltracker.com/story/show/162241874)