### PR TITLE
#162366615 Fix redirection bug on login page

### DIFF
--- a/src/components/authentication/LoginForm.js
+++ b/src/components/authentication/LoginForm.js
@@ -57,7 +57,7 @@ const LoginForm = ({
               Login
             </button>
             <div className="form-group">
-              <Link className="theme-text center-text" exact to="/forgotPassword">Have no account?</Link>
+              <Link className="theme-text center-text" exact to="/signup">Have no account?</Link>
             </div>
           </form>
         </div>


### PR DESCRIPTION
### What does this PR do?

Fixes the bug where user without an account is redirected to forgot-password page instead of signup page

#### Description of Task to be completed?

Currently, when user clicks on the link for `Have no account?` on the login page, the user is redirected to the page for `forgot-password`

This PR redirection to signup page if a user already has an account

#### How should this be manually tested?

Open the app at `http://localhost:3000/login` and click on `Have no account?` link. You should be redirected to the `signup` page


#### What are the relevant pivotal tracker stories?

- [#162366615](https://www.pivotaltracker.com/story/show/162366615)